### PR TITLE
Provider version constraints is deprecated now.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "~> 2.7"
   region  = var.aws_region
 }
 


### PR DESCRIPTION
The provider version constraints is deprecated, this change will remove the warning message from the plan output.